### PR TITLE
Fix empty carrier name

### DIFF
--- a/Sources/RMBTConnectivity.m
+++ b/Sources/RMBTConnectivity.m
@@ -258,17 +258,17 @@
         if (_networkName) result[@"wifi_ssid"] = _networkName;
         if (_bssid) result[@"wifi_bssid"] = _bssid;
     } else if (self.networkType == RMBTNetworkTypeCellular) {
+        //TODO: Imrove this code. Sometimes iPhone 12 always send two dictionaries as dial sim. We take first where we have carrier name
         if (_dualSim) {
             result[@"dual_sim"] = @YES;
         }
-        else {
-            if (_cellularCode) {
-                result[@"network_type"] = _cellularCode;
-            }
-            result[@"telephony_network_sim_operator_name"] = RMBTValueOrNull(self.networkName);
-            result[@"telephony_network_sim_country"] = RMBTValueOrNull(_telephonyNetworkSimCountry);
-            result[@"telephony_network_sim_operator"] = RMBTValueOrNull(_telephonyNetworkSimOperator);
+
+        if (_cellularCode) {
+            result[@"network_type"] = _cellularCode;
         }
+        result[@"telephony_network_sim_operator_name"] = RMBTValueOrNull(self.networkName);
+        result[@"telephony_network_sim_country"] = RMBTValueOrNull(_telephonyNetworkSimCountry);
+        result[@"telephony_network_sim_operator"] = RMBTValueOrNull(_telephonyNetworkSimOperator);
         
     }
     return result;

--- a/Sources/RMBTConnectivity.m
+++ b/Sources/RMBTConnectivity.m
@@ -93,9 +93,14 @@
                         //one SIM card - default case for now, use this
                         carrier = allCarriers[0];
                     }
-                    else if (allCarriers.count > 1) {
+                    else if (allCarriers.count > 1) { //iPhone 12 return 2 dictionaries. 1 for primary sim, 2 for eSim, but with empty values. We try find first with any carrier name. In the future we have to improve this code
                         //dual SIM, we cannot handle this at the moment
                         _dualSim = YES;
+                        for (CTCarrier *c in allCarriers) {
+                            if ((c.carrierName != nil) && (c.carrierName.length > 0)) {
+                                carrier = c;
+                            }
+                        }
                     }
                     else {
                         //no SIM inserted
@@ -106,7 +111,7 @@
                 carrier = [netinfo subscriberCellularProvider];
             }
             
-            if (!_dualSim) {
+            if (carrier) {
                 _networkName = carrier.carrierName;
                 _telephonyNetworkSimCountry = carrier.isoCountryCode;
                 _telephonyNetworkSimOperator = [NSString stringWithFormat:@"%@-%@", carrier.mobileCountryCode, carrier.mobileNetworkCode];


### PR DESCRIPTION
Sometimes we get two dictionaries of CTCarrier, one for primary SIM and another for eSim. eSim could be not used, but we have two dictionaries. For now, I search first dictionary with operator name and use all information from this CTCarrier as if we get 1 dictionary.
Also I send dualSim option but it more for statistic