### PR TITLE
fix crash in connectivity

### DIFF
--- a/Sources/RMBTConnectivity.m
+++ b/Sources/RMBTConnectivity.m
@@ -167,7 +167,7 @@
             CTRadioAccessTechnologyLTE:          @(13),
             CTRadioAccessTechnologyeHRPD:        @(14),
         }];
-        if (@available(iOS 14.0, *)) {
+        if (@available(iOS 14.1, *)) {
             _lookup[CTRadioAccessTechnologyNRNSA] = @(41);
             _lookup[CTRadioAccessTechnologyNR] = @(20);
         }
@@ -195,7 +195,7 @@
             CTRadioAccessTechnologyLTE:             @"LTE (4G)",
             CTRadioAccessTechnologyeHRPD:           @"HRPD (2G)",
         }];
-        if (@available(iOS 14.0, *)) {
+        if (@available(iOS 14.1, *)) {
             _lookup[CTRadioAccessTechnologyNRNSA] = @"NRNSA (5G)";
             _lookup[CTRadioAccessTechnologyNR] = @"NR (5G)";
         }


### PR DESCRIPTION
I tested crash with 
iOS 13.5.1 one sim iPhone 8
iOS 14.0.1 one sim iPhone 8
iOS 14.3 dual sim(eSim) iPhone 12 mini

The problem that CTRadioAccessTechnologyNRNSA not exist in iOS 14.0 but SDK show that it exist. When we try to add it to dictionary we have crash. I think it same with CTRadioAccessTechnologyNR