### PR TITLE
ONT-4815/fix-ips-status-icon

### DIFF
--- a/Sources/RMBTIntroViewController.swift
+++ b/Sources/RMBTIntroViewController.swift
@@ -311,7 +311,7 @@ class RMBTIntroViewController: UIViewController {
         
         guard let location = RMBTLocationTracker.shared.location else { return }
         
-        var params = connectivity.testResultDictionary() ?? [:]
+        var params = connectivity.testResultDictionary()
         let locationParams = location.paramsDictionary()
         for param in locationParams {
             params[param.key] = param.value
@@ -332,24 +332,25 @@ class RMBTIntroViewController: UIViewController {
             return
         }
         
-        if (connectivity.ipv4.internalIp != nil) {
+        
+        if (connectivity.ipv4.internalIp == nil) || (connectivity.ipv4.externalIp == nil) {
+            currentView.ipV4TintColor = .ipNotAvailable
+        } else {
             if (connectivity.ipv4.externalIp != nil) && (connectivity.ipv4.externalIp == connectivity.ipv4.internalIp) {
                 currentView.ipV4TintColor = .ipAvailable
             } else {
                 currentView.ipV4TintColor = .ipSemiAvailable
             }
-        } else {
-            currentView.ipV4TintColor = .ipNotAvailable
         }
         
-        if (connectivity.ipv6.internalIp != nil) {
+        if (connectivity.ipv6.internalIp == nil) || (connectivity.ipv6.externalIp == nil) {
+            currentView.ipV6TintColor = .ipNotAvailable
+        } else {
             if (connectivity.ipv6.externalIp != nil) && (connectivity.ipv6.externalIp == connectivity.ipv6.internalIp) {
                 currentView.ipV6TintColor = .ipAvailable
             } else {
                 currentView.ipV6TintColor = .ipSemiAvailable
             }
-        } else {
-            currentView.ipV6TintColor = .ipNotAvailable
         }
         
         currentView.locationTintColor = CLLocationManager.authorizationStatus() != .denied ? .ipAvailable : .ipNotAvailable

--- a/Sources/RMBTTestResult.swift
+++ b/Sources/RMBTTestResult.swift
@@ -298,7 +298,7 @@ import CoreLocation
         var networkType: Int = -1
         
         for c in connectivities {
-            guard let cResult = c.testResultDictionary() as? [String: Any] else { continue }
+            let cResult = c.testResultDictionary()
             signals.append([
                 "time": RMBTHelpers.RMBTTimestamp(with: c.timestamp),
                 "network_type_id": cResult["network_type"] as? Int ?? 0


### PR DESCRIPTION
- fix ips status icons color

Expected Nr. 1: 
If we have private iPV6 address and no public, the icon should be red. 
If we have different public and private address the icon should be yellow/orange. 
If the ipv6 private and public addresses are the same, the icon is green. 
If we have local address and no server address it should be red. 