### PR TITLE
Fix compilation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ xcuserdata
 .idea
 *.xcworkspace
 
-Configs/
+/Configs/
 Pods/
 Resources/RMBT-Info.plist
 Resources/Images.xcassets/AppIcon.appiconset/

--- a/RMBT.xcodeproj/project.pbxproj
+++ b/RMBT.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		36B75A212739692C006F4CB3 /* RMBTMaterialTextFieldState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B75A202739692C006F4CB3 /* RMBTMaterialTextFieldState.swift */; };
 		36B75A27273EA096006F4CB3 /* RMBTHistoryLoopCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 36B75A26273EA096006F4CB3 /* RMBTHistoryLoopCell.xib */; };
 		36B75A29273EA73C006F4CB3 /* RMBTHistoryLoopCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B75A28273EA73C006F4CB3 /* RMBTHistoryLoopCell.swift */; };
-		49C86FDD2AFBBF1500663CE2 /* RMBTConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C86FDC2AFBBF1500663CE2 /* RMBTConfig.swift */; };
+		49F976802B0B3E880098C4CC /* RMBTConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C86FDC2AFBBF1500663CE2 /* RMBTConfig.swift */; };
 		C573F2A5175281D300C728FC /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C573F2A4175281D300C728FC /* MapKit.framework */; };
 		C573F2B1175294A500C728FC /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C573F2B0175294A500C728FC /* CoreLocation.framework */; };
 		C5DEB476176364B100187C94 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5DEB475176364B100187C94 /* AVFoundation.framework */; };
@@ -1514,6 +1514,8 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
+			inputFileListPaths = (
+			);
 			inputPaths = (
 			);
 			name = "Run Script: Add Build Infos";
@@ -1577,6 +1579,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49F976802B0B3E880098C4CC /* RMBTConfig.swift in Sources */,
 				E9400EE426BA32150067273A /* Log.swift in Sources */,
 				E9BF00EB2760F01F0092371F /* RMBTLoopModeConfirmationViewController.swift in Sources */,
 				E946B94A26D62EAA0006E1F1 /* RMBTBottomPresentSegue.swift in Sources */,
@@ -1649,7 +1652,6 @@
 				E9E993F826EC822300E7EED6 /* QosMeasurementSubmitResponse.swift in Sources */,
 				E91316BA26ADCB7300368DCD /* RMBTIntroViewController.swift in Sources */,
 				E99765B926FD885E009A1A4C /* UIFont+Roboto.swift in Sources */,
-				49C86FDD2AFBBF1500663CE2 /* RMBTConfig.swift in Sources */,
 				E91316B026AD95B300368DCD /* RMBTTOS.swift in Sources */,
 				36933A7B274FE1E0009A52BE /* RMBTTestDetailTitleCell.swift in Sources */,
 				E97CF7892761F8930092352C /* CLLocation+RMBTFormat.swift in Sources */,

--- a/public/Configurations/Configs/RMBTConfig.swift
+++ b/public/Configurations/Configs/RMBTConfig.swift
@@ -1,0 +1,121 @@
+//
+//  RMBTConfig.swift
+//  RMBT
+//
+//  Created by Sergey Glushchenko on 04.08.2021.
+//  Copyright © 2021 appscape gmbh. All rights reserved.
+//
+
+import UIKit
+
+/// default qos socket character encoding
+let QOS_SOCKET_DEFAULT_CHARACTER_ENCODING: UInt = String.Encoding.utf8.rawValue
+
+public let DEFAULT_LANGUAGE = "en"
+public let PREFFERED_LANGUAGE = Bundle.main.preferredLocalizations.first ?? DEFAULT_LANGUAGE
+
+public class RMBTConfig {
+    public static let shared: RMBTConfig = {
+        let config = RMBTConfig()
+        LogConfig.initLoggingFramework()
+        return config
+    }()
+    
+    var RMBT_USE_MAIN_LANGUAGE: Bool { return false }
+    var RMBT_MAIN_LANGUAGE: String { return "en" }
+    
+    let RMBT_DEFAULT_IS_CURRENT_COUNTRY: Bool = true
+    
+    var RMBT_CHECK_IPV4_URL: String {
+        return "\(RMBT_IPV4_URL_HOST)\(RMBT_CONTROL_SERVER_PATH)/ip"
+    }
+    
+    var RMBT_CONTROL_SERVER_URL: String {
+        return "\(RMBT_URL_HOST)\(RMBT_CONTROL_SERVER_PATH)"
+    }
+    
+    var RMBT_MAP_SERVER_URL: String { return "\(RMBT_URL_HOST)\(RMBT_MAP_SERVER_PATH)" }
+
+
+    var RMBT_URL_HOST: String { return "https://example.com" }
+    // Control server base URL used when user has enabled the "IPv4-Only" setting
+    var RMBT_IPV4_URL_HOST: String { return "https://example.com" }
+    // Ditto for the (debug) "IPv6-Only" setting
+    var RMBT_IPV6_URL_HOST: String { return "https://example.com" }
+
+    var RMBT_CONTROL_SERVER_PATH: String { return "/RMBTControlServer" }
+    var RMBT_MAP_SERVER_PATH: String { return "/RMBTMapServer" }
+
+    //Colors
+    static let darkColor = UIColor.rmbt_color(withRGBHex: 0xFFFFFF)
+    static let tintColor = UIColor.rmbt_color(withRGBHex: 0x424242)
+    
+    static let ACTIVATE_DEV_CODE = "88888888"
+    static let DEACTIVATE_DEV_CODE = "00000000"
+    
+    static let RMBT_TEST_LOOPMODE_MIN_COUNT = 1
+    static let RMBT_TEST_LOOPMODE_DEFAULT_COUNT = 10
+    static let RMBT_TEST_LOOPMODE_MAX_COUNT = 100
+
+    // Loop mode will stop automatically after this many seconds:
+    static let RMBT_TEST_LOOPMODE_MAX_DURATION_S = (48*60*60) // 48 hours
+
+    // Minimum/maximum number of minutes that user can choose to wait before next test is started:
+    static let RMBT_TEST_LOOPMODE_MIN_DELAY_MINS = 5
+    static let RMBT_TEST_LOOPMODE_DEFAULT_DELAY_MINS = 10
+    static let RMBT_TEST_LOOPMODE_MAX_DELAY_MINS = (24 * 60) // one day
+
+    // ... meters user locations must change before next test is started:
+    static let RMBT_TEST_LOOPMODE_MIN_MOVEMENT_M = 50
+    static let RMBT_TEST_LOOPMODE_DEFAULT_MOVEMENT_M = 250
+    static let RMBT_TEST_LOOPMODE_MAX_MOVEMENT_M = 10000
+    
+    // Note: $lang will be replaced by "de" is device language is german, or "en" in any other case:
+    static let RMBT_PROJECT_URL = "https://example.com/"
+    static let RMBT_PROJECT_EMAIL = "mail@example.com"
+    static let RMBT_PRIVACY_TOS_URL = "https://example.com/$lang/tc_ios.html"
+    static let RMBT_ABOUT_URL = "https://example.com/$lang/"
+
+    // Note: stats url can can be replaced with the /settings response from control server
+    static let RMBT_STATS_URL = "https://example.com/$lang/Statistik#noMMenu"
+
+    static let RMBT_HELP_URL = "https://example.com/redirect/$lang/help"
+
+    static let RMBT_REPO_URL = "https://github.com/rtr-nettest/open-rmbt-ios"
+    static let RMBT_DEVELOPER_URL = "https://example.com/"
+    static let RMBT_DEVELOPER_NAME = "your name"
+
+    // Current TOS version. Bump to force displaying TOS to users again.
+    static let RMBT_TOS_VERSION = 6
+    
+    
+    static let RMBT_MAP_AUTO_TRESHOLD_ZOOM = 12
+    
+    
+    // Timeout for connecting and reading responses back from QoS control server
+    static let RMBT_QOS_CC_TIMEOUT_S = 5.0
+    static let RMBT_TEST_SOCKET_TIMEOUT_S = 30.0
+    
+    // The getaddrinfo() used by GCDAsync socket will fail immediately if the hostname of the test server
+    // is not in the DNS cache. To work around this, in case of this particular error we will retry couple
+    // of times before giving up:
+    static let RMBT_TEST_HOST_LOOKUP_RETRIES = 1 // How many times to retry
+    static let RMBT_TEST_HOST_LOOKUP_WAIT_S = 0.2 // How long to wait before next retry
+    
+    // In case of slow upload, we finalize the test even if this many seconds still haven't been received:
+    static let RMBT_TEST_UPLOAD_MAX_DISCARD_S = 1.0
+
+    // Minimum number of seconds to wait after sending last chunk, before starting to discard.
+    static let RMBT_TEST_UPLOAD_MIN_WAIT_S = 0.25
+
+    // Maximum number of seconds to wait for server reports after last chunk has been sent.
+    // After this interval we will close the socket and finish the test on first report received.
+    static let RMBT_TEST_UPLOAD_MAX_WAIT_S = 3
+
+    // Measure and submit speed during test in these intervals
+    static let RMBT_TEST_SAMPLING_RESOLUTION_MS = 100
+    
+    static let RMBT_TEST_PRETEST_MIN_CHUNKS_FOR_MULTITHREADED_TEST = 4
+    static let RMBT_TEST_PRETEST_DURATION_S = 2.0
+    static let RMBT_TEST_PING_COUNT = 10
+}

--- a/public/Configurations/Configs/RMBTConfig.swift
+++ b/public/Configurations/Configs/RMBTConfig.swift
@@ -24,31 +24,16 @@ public class RMBTConfig {
     var RMBT_USE_MAIN_LANGUAGE: Bool { return false }
     var RMBT_MAIN_LANGUAGE: String { return "en" }
     
-    let RMBT_DEFAULT_IS_CURRENT_COUNTRY: Bool = true
-    
-    var RMBT_CHECK_IPV4_URL: String {
-        return "\(RMBT_IPV4_URL_HOST)\(RMBT_CONTROL_SERVER_PATH)/ip"
-    }
-    
     var RMBT_CONTROL_SERVER_URL: String {
         return "\(RMBT_URL_HOST)\(RMBT_CONTROL_SERVER_PATH)"
     }
-    
-    var RMBT_MAP_SERVER_URL: String { return "\(RMBT_URL_HOST)\(RMBT_MAP_SERVER_PATH)" }
-
 
     var RMBT_URL_HOST: String { return "https://example.com" }
     // Control server base URL used when user has enabled the "IPv4-Only" setting
-    var RMBT_IPV4_URL_HOST: String { return "https://example.com" }
     // Ditto for the (debug) "IPv6-Only" setting
     var RMBT_IPV6_URL_HOST: String { return "https://example.com" }
 
     var RMBT_CONTROL_SERVER_PATH: String { return "/RMBTControlServer" }
-    var RMBT_MAP_SERVER_PATH: String { return "/RMBTMapServer" }
-
-    //Colors
-    static let darkColor = UIColor.rmbt_color(withRGBHex: 0xFFFFFF)
-    static let tintColor = UIColor.rmbt_color(withRGBHex: 0x424242)
     
     static let ACTIVATE_DEV_CODE = "88888888"
     static let DEACTIVATE_DEV_CODE = "00000000"
@@ -56,9 +41,6 @@ public class RMBTConfig {
     static let RMBT_TEST_LOOPMODE_MIN_COUNT = 1
     static let RMBT_TEST_LOOPMODE_DEFAULT_COUNT = 10
     static let RMBT_TEST_LOOPMODE_MAX_COUNT = 100
-
-    // Loop mode will stop automatically after this many seconds:
-    static let RMBT_TEST_LOOPMODE_MAX_DURATION_S = (48*60*60) // 48 hours
 
     // Minimum/maximum number of minutes that user can choose to wait before next test is started:
     static let RMBT_TEST_LOOPMODE_MIN_DELAY_MINS = 5
@@ -74,12 +56,9 @@ public class RMBTConfig {
     static let RMBT_PROJECT_URL = "https://example.com/"
     static let RMBT_PROJECT_EMAIL = "mail@example.com"
     static let RMBT_PRIVACY_TOS_URL = "https://example.com/$lang/tc_ios.html"
-    static let RMBT_ABOUT_URL = "https://example.com/$lang/"
 
     // Note: stats url can can be replaced with the /settings response from control server
     static let RMBT_STATS_URL = "https://example.com/$lang/Statistik#noMMenu"
-
-    static let RMBT_HELP_URL = "https://example.com/redirect/$lang/help"
 
     static let RMBT_REPO_URL = "https://github.com/rtr-nettest/open-rmbt-ios"
     static let RMBT_DEVELOPER_URL = "https://example.com/"


### PR DESCRIPTION
This PR fixes the issue that the current repository cannot be compiled because of missing configuration files stored only inside the `private` folder linked as a private git submodule.

# Solution

Add the `RMBTConfig.swift` file with dummy values into the `public` folder and make git ignore only the `/Configs` folder but not the `Configs` folder inside the `public` folder. This way the Xcode has some `RMBTConfig.swift` to start with and can compile without requiring to access private submodule.

There is some limitation, however. There is still a build error on the very first run after the new repository clone. This comes from how overriding the public Config with the Private one is set up.
From the second compilation onward the build works without any errors.