### PR TITLE
Fix VoiceOver

### DIFF
--- a/Sources/Views/RMBTPopupViewController.swift
+++ b/Sources/Views/RMBTPopupViewController.swift
@@ -120,6 +120,11 @@ class RMBTPopupViewController: UIViewController {
         self.infoTypeImageView?.image = info?.icon
         self.infoTypeImageView?.image = self.infoTypeImageView?.image?.withRenderingMode(.alwaysTemplate)
         self.infoTypeImageView?.tintColor = self.info?.tintColor
+
+        if self.info?.values.count == 0 {
+            infoTypeImageView?.isAccessibilityElement = true
+            infoTypeImageView?.accessibilityLabel = ipNotAvailableLabel?.text
+        }
         self.collectionView.reloadData()
     }
     


### PR DESCRIPTION
This PR adds a quick fix for no VoiceOver elements on RMBTPopupViewController in case no IP address is available.

In this case, only an image and `ipNotAvailableLabel` is shown. But the label for some reason does not react on VoiceOver, thus there is no active element, resulting in the user being stuck on the popup and unable to leave it.
To fix this I've added accessibility information to the image element as well, so there is an active element. This way the VoiceOver reads the information and the popup can be closed.
