### PR TITLE
Better QoS activity indication

### DIFF
--- a/Sources/Test/View/RMBTTestLandscapeView.xib
+++ b/Sources/Test/View/RMBTTestLandscapeView.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_5" orientation="landscape" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -47,7 +46,7 @@
                     <rect key="frame" x="163.66666666666666" y="271" width="22" height="22"/>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Technology" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Keq-Rl-3So">
-                    <rect key="frame" x="586" y="63.999999999999993" width="73" height="16.666666666666664"/>
+                    <rect key="frame" x="586" y="63.999999999999993" width="72.666666666666629" height="16.666666666666664"/>
                     <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="14"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="0.40434400079999999" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
@@ -56,7 +55,7 @@
                     </userDefinedRuntimeAttributes>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Netzwerk" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="81a-ky-7bD">
-                    <rect key="frame" x="396" y="63.999999999999993" width="59" height="16.666666666666664"/>
+                    <rect key="frame" x="396" y="63.999999999999993" width="59.333333333333314" height="16.666666666666664"/>
                     <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="14"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="0.40434400079999999" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
@@ -83,13 +82,13 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="100" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oWL-Xy-LvL">
-                    <rect key="frame" x="235" y="96.666666666666686" width="37" height="75"/>
+                    <rect key="frame" x="235" y="96.666666666666686" width="36.666666666666686" height="75"/>
                     <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="64"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ptR-ei-CQl">
-                    <rect key="frame" x="272" y="137.33333333333334" width="15" height="23"/>
+                    <rect key="frame" x="271.66666666666669" y="137.33333333333334" width="15" height="23.666666666666657"/>
                     <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="20"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
@@ -106,20 +105,35 @@
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vNU-St-fgN">
+                    <rect key="frame" x="83.000000000000014" y="255.33333333333337" width="147.33333333333337" height="75"/>
+                    <subviews>
+                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="owg-9B-OOh">
+                            <rect key="frame" x="0.0" y="27.333333333333343" width="20" height="20"/>
+                            <color key="color" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </activityIndicatorView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="QoS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6kE-hk-ZNV">
+                            <rect key="frame" x="27.999999999999993" y="0.0" width="119.33333333333331" height="75"/>
+                            <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="64"/>
+                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                </stackView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cqL-FH-5V7">
                     <rect key="frame" x="396" y="232.66666666666663" width="340" height="181.33333333333337"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rm4-3Y-Uxe">
-                            <rect key="frame" x="272.66666666666663" y="16" width="51.333333333333314" height="16"/>
+                            <rect key="frame" x="272.33333333333337" y="16" width="51.666666666666686" height="16"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0/7" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Uc-B3-NBb">
-                                    <rect key="frame" x="0.0" y="0.66666666666668561" width="18.333333333333332" height="15"/>
+                                    <rect key="frame" x="0.0" y="1.0000000000000009" width="18.666666666666668" height="14.333333333333336"/>
                                     <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                     <color key="textColor" red="0.94901960780000005" green="0.95294117649999999" blue="0.96078431369999995" alpha="0.57999999999999996" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a8f-ch-XdN" customClass="RMBTLoaderView" customModule="RMBT" customModuleProvider="target">
-                                    <rect key="frame" x="35.333333333333371" y="0.0" width="16" height="16"/>
+                                    <rect key="frame" x="35.666666666666629" y="0.0" width="16" height="16"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="16" id="XZA-T0-8s2"/>
@@ -220,7 +234,7 @@
                                     <rect key="frame" x="272.33333333333337" y="15.999999999999986" width="51.666666666666686" height="16"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0/7" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EPt-Qa-jGc">
-                                            <rect key="frame" x="0.0" y="0.66666666666668561" width="18.666666666666668" height="15"/>
+                                            <rect key="frame" x="0.0" y="1.0000000000000009" width="18.666666666666668" height="14.333333333333336"/>
                                             <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                             <color key="textColor" red="0.94901960780000005" green="0.95294117649999999" blue="0.96078431369999995" alpha="0.57999999999999996" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
@@ -471,6 +485,7 @@
                 <constraint firstItem="XLw-Xr-akL" firstAttribute="top" secondItem="LcP-0S-akf" secondAttribute="bottom" constant="17" id="JiO-IX-iSi"/>
                 <constraint firstItem="ZeX-b8-Y0I" firstAttribute="leading" secondItem="e5D-yU-MNC" secondAttribute="trailing" id="Jrh-et-N3K"/>
                 <constraint firstItem="ptR-ei-CQl" firstAttribute="firstBaseline" secondItem="oWL-Xy-LvL" secondAttribute="firstBaseline" id="KaJ-DX-Yx5"/>
+                <constraint firstItem="vNU-St-fgN" firstAttribute="centerX" secondItem="eJK-yj-IVB" secondAttribute="centerX" constant="24" id="LLb-CA-47g"/>
                 <constraint firstItem="Keq-Rl-3So" firstAttribute="top" secondItem="e7e-0V-rYM" secondAttribute="top" constant="64" id="M1U-1l-eTY"/>
                 <constraint firstItem="JNo-0A-VNg" firstAttribute="firstBaseline" secondItem="e5D-yU-MNC" secondAttribute="firstBaseline" id="O4s-Aa-0R4"/>
                 <constraint firstItem="e5D-yU-MNC" firstAttribute="centerX" secondItem="eJK-yj-IVB" secondAttribute="centerX" constant="10" id="Pdd-AS-z7l"/>
@@ -490,6 +505,7 @@
                 <constraint firstItem="sd5-2S-FF7" firstAttribute="leading" secondItem="e7e-0V-rYM" secondAttribute="leading" id="i27-gg-nFp"/>
                 <constraint firstItem="OVe-gJ-LZa" firstAttribute="leading" secondItem="eJK-yj-IVB" secondAttribute="trailing" multiplier="0.95" constant="-60" id="iUi-Xs-MYn"/>
                 <constraint firstItem="e7e-0V-rYM" firstAttribute="bottom" secondItem="iiz-Hc-GK4" secondAttribute="bottom" constant="20" id="mIM-f0-RXB"/>
+                <constraint firstItem="vNU-St-fgN" firstAttribute="centerY" secondItem="eJK-yj-IVB" secondAttribute="centerY" id="n32-bn-gDZ"/>
                 <constraint firstItem="cqL-FH-5V7" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iiz-Hc-GK4" secondAttribute="trailing" constant="20" id="nSE-WJ-oMg"/>
                 <constraint firstItem="LcP-0S-akf" firstAttribute="top" secondItem="Keq-Rl-3So" secondAttribute="bottom" id="p5y-Xz-zMX"/>
                 <constraint firstItem="JNo-0A-VNg" firstAttribute="top" secondItem="ZeX-b8-Y0I" secondAttribute="bottom" constant="6" id="qoP-0k-fGL"/>
@@ -527,6 +543,7 @@
                 <outlet property="pingResultLabel" destination="oh4-SD-lOB" id="nz4-E3-Ho8"/>
                 <outlet property="progressGaugePlaceholderView" destination="OVe-gJ-LZa" id="aHx-1i-3b9"/>
                 <outlet property="progressLabel" destination="oWL-Xy-LvL" id="h3P-w0-iB7"/>
+                <outlet property="qosProgressLabelContainer" destination="vNU-St-fgN" id="hDb-Q5-Tni"/>
                 <outlet property="qosProgressView" destination="Y5P-9h-OrJ" id="JdA-ih-V65"/>
                 <outlet property="rootGaugeView" destination="iiz-Hc-GK4" id="hVF-NV-KDq"/>
                 <outlet property="rootWaitingView" destination="43g-kd-9kE" id="Z9o-dY-h2g"/>

--- a/Sources/Test/View/RMBTTestLandscapeView.xib
+++ b/Sources/Test/View/RMBTTestLandscapeView.xib
@@ -106,15 +106,15 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vNU-St-fgN">
-                    <rect key="frame" x="83.000000000000014" y="255.33333333333337" width="147.33333333333337" height="75"/>
+                    <rect key="frame" x="104.66666666666669" y="270.33333333333331" width="116" height="44.666666666666686"/>
                     <subviews>
-                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="owg-9B-OOh">
-                            <rect key="frame" x="0.0" y="27.333333333333343" width="20" height="20"/>
+                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="owg-9B-OOh">
+                            <rect key="frame" x="0.0" y="4" width="37" height="37"/>
                             <color key="color" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </activityIndicatorView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="QoS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6kE-hk-ZNV">
-                            <rect key="frame" x="27.999999999999993" y="0.0" width="119.33333333333331" height="75"/>
-                            <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="64"/>
+                            <rect key="frame" x="44.999999999999986" y="0.0" width="71" height="44.666666666666664"/>
+                            <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="38"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
@@ -485,7 +485,7 @@
                 <constraint firstItem="XLw-Xr-akL" firstAttribute="top" secondItem="LcP-0S-akf" secondAttribute="bottom" constant="17" id="JiO-IX-iSi"/>
                 <constraint firstItem="ZeX-b8-Y0I" firstAttribute="leading" secondItem="e5D-yU-MNC" secondAttribute="trailing" id="Jrh-et-N3K"/>
                 <constraint firstItem="ptR-ei-CQl" firstAttribute="firstBaseline" secondItem="oWL-Xy-LvL" secondAttribute="firstBaseline" id="KaJ-DX-Yx5"/>
-                <constraint firstItem="vNU-St-fgN" firstAttribute="centerX" secondItem="eJK-yj-IVB" secondAttribute="centerX" constant="24" id="LLb-CA-47g"/>
+                <constraint firstItem="vNU-St-fgN" firstAttribute="centerX" secondItem="eJK-yj-IVB" secondAttribute="centerX" constant="30" id="LLb-CA-47g"/>
                 <constraint firstItem="Keq-Rl-3So" firstAttribute="top" secondItem="e7e-0V-rYM" secondAttribute="top" constant="64" id="M1U-1l-eTY"/>
                 <constraint firstItem="JNo-0A-VNg" firstAttribute="firstBaseline" secondItem="e5D-yU-MNC" secondAttribute="firstBaseline" id="O4s-Aa-0R4"/>
                 <constraint firstItem="e5D-yU-MNC" firstAttribute="centerX" secondItem="eJK-yj-IVB" secondAttribute="centerX" constant="10" id="Pdd-AS-z7l"/>

--- a/Sources/Test/View/RMBTTestPortraitView.swift
+++ b/Sources/Test/View/RMBTTestPortraitView.swift
@@ -70,6 +70,7 @@ class RMBTTestPortraitView: UIView, XibLoadable {
     
     // QoS
     @IBOutlet weak var qosProgressView: UIView!
+    @IBOutlet weak var qosProgressLabelContainer: UIStackView!
 
     // Loop Mode Waiting
     @IBOutlet weak var loopModeWaitingView: UIView!
@@ -267,17 +268,18 @@ class RMBTTestPortraitView: UIView, XibLoadable {
         self.counterAnimationView.isAnimating = true
     }
     
-    @objc func showQoSUI(_ state: Bool) {
-        self.speedGraphView.isHidden = state
-        self.pingGraphView.isHidden = state
+    @objc func showQoSUI(_ shouldShowQoS: Bool) {
+        self.speedGraphView.isHidden = shouldShowQoS
+        self.pingGraphView.isHidden = shouldShowQoS
     //    _speedGaugeView.hidden = state
-        self.speedLabel.isHidden = state
-        self.speedSuffixLabel.isHidden = state
+        self.speedLabel.isHidden = shouldShowQoS
+        self.qosProgressLabelContainer.isHidden = !shouldShowQoS
+        self.speedSuffixLabel.isHidden = shouldShowQoS
         self.speedGaugeView.value = 0.0
-        self.speedSuffixLabel.isHidden = state
-        self.arrowImageView.isHidden = state
-        self.qosProgressView.isHidden = !state
-        if state == false {
+        self.speedSuffixLabel.isHidden = shouldShowQoS
+        self.arrowImageView.isHidden = shouldShowQoS
+        self.qosProgressView.isHidden = !shouldShowQoS
+        if shouldShowQoS == false {
             self.updatePhase()
         }
     }
@@ -290,6 +292,7 @@ class RMBTTestPortraitView: UIView, XibLoadable {
         self.speedGaugeView.value = 0.0
         self.progressGaugeView.value = 0.0
         self.speedLabel.text = "--"
+        self.qosProgressLabelContainer.isHidden = true
         self.progressLabel.text = "--"
         self.speedSuffixLabel.isHidden = true
     }
@@ -331,6 +334,7 @@ class RMBTTestPortraitView: UIView, XibLoadable {
 
         speedGaugeView.value = 0.0
         self.speedLabel.text = ""
+        self.qosProgressLabelContainer.isHidden = true
         self.speedSuffixLabel.isHidden = true
         self.speedGraphView.clear()
         self.pingGraphView.clear()
@@ -391,6 +395,7 @@ class RMBTTestPortraitView: UIView, XibLoadable {
             self.speedGraphView.isHidden = false
             self.speedGraphView.clear()
             self.speedLabel.text = ""
+            self.qosProgressLabelContainer.isHidden = true
             self.speedSuffixLabel.isHidden = true
             self.arrowImageView.image = UIImage(named: "upload_icon")
         } else {
@@ -409,7 +414,8 @@ class RMBTTestPortraitView: UIView, XibLoadable {
         
         self.progressGaugePlaceholderView.isHidden = true
         self.speedGaugePlaceholderView.isHidden = true
-        
+        self.qosProgressLabelContainer.isHidden = true
+
         self.updateDetailInfoView()
         
         self.infoTitleView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(infoViewTap)))

--- a/Sources/Test/View/RMBTTestPortraitView.xib
+++ b/Sources/Test/View/RMBTTestPortraitView.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -79,7 +78,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="100" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oWL-Xy-LvL">
-                    <rect key="frame" x="250.5" y="219" width="37" height="75"/>
+                    <rect key="frame" x="250.5" y="219" width="36.5" height="75"/>
                     <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="64"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
@@ -88,7 +87,7 @@
                     <rect key="frame" x="0.0" y="521.5" width="414" height="36.5"/>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ptR-ei-CQl">
-                    <rect key="frame" x="287.5" y="260" width="15" height="23"/>
+                    <rect key="frame" x="287" y="260" width="15" height="23.5"/>
                     <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="20"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
@@ -105,6 +104,25 @@
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PR6-3d-8vK">
+                    <rect key="frame" x="85.5" y="399.5" width="147.5" height="75"/>
+                    <subviews>
+                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="43e-6e-tGj">
+                            <rect key="frame" x="0.0" y="27.5" width="20" height="20"/>
+                            <color key="color" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </activityIndicatorView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="QoS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e76-bN-8pV">
+                            <rect key="frame" x="28" y="0.0" width="119.5" height="75"/>
+                            <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="64"/>
+                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="e76-bN-8pV" secondAttribute="bottom" id="5BA-hs-On2"/>
+                        <constraint firstItem="e76-bN-8pV" firstAttribute="top" secondItem="PR6-3d-8vK" secondAttribute="top" id="liu-Vh-Gbq"/>
+                    </constraints>
+                </stackView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cqL-FH-5V7">
                     <rect key="frame" x="0.0" y="669" width="414" height="193"/>
                     <subviews>
@@ -112,7 +130,7 @@
                             <rect key="frame" x="353" y="16" width="45" height="16"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-/-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Uc-B3-NBb">
-                                    <rect key="frame" x="0.0" y="0.5" width="12" height="15"/>
+                                    <rect key="frame" x="0.0" y="1" width="12" height="14.5"/>
                                     <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                     <color key="textColor" red="0.94901960780000005" green="0.95294117649999999" blue="0.96078431369999995" alpha="0.57999999999999996" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>
@@ -211,7 +229,7 @@
                                     <rect key="frame" x="346.5" y="16" width="51.5" height="16"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0/7" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EPt-Qa-jGc">
-                                            <rect key="frame" x="0.0" y="0.5" width="18.5" height="15"/>
+                                            <rect key="frame" x="0.0" y="1" width="18.5" height="14.5"/>
                                             <fontDescription key="fontDescription" name="Roboto-Regular" family="Roboto" pointSize="12"/>
                                             <color key="textColor" red="0.94901960780000005" green="0.95294117649999999" blue="0.96078431369999995" alpha="0.57999999999999996" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
@@ -466,6 +484,7 @@
                 <constraint firstItem="e5D-yU-MNC" firstAttribute="centerX" secondItem="eJK-yj-IVB" secondAttribute="centerX" constant="10" id="Pdd-AS-z7l"/>
                 <constraint firstItem="iiz-Hc-GK4" firstAttribute="leading" secondItem="e7e-0V-rYM" secondAttribute="leading" constant="20" id="PkP-rM-qi9"/>
                 <constraint firstItem="LcP-0S-akf" firstAttribute="leading" secondItem="Keq-Rl-3So" secondAttribute="leading" id="T9L-Px-v3g"/>
+                <constraint firstItem="PR6-3d-8vK" firstAttribute="centerY" secondItem="eJK-yj-IVB" secondAttribute="centerY" id="Ubr-Gc-Bur"/>
                 <constraint firstItem="iiz-Hc-GK4" firstAttribute="top" secondItem="OVe-gJ-LZa" secondAttribute="top" id="V33-Fc-otC"/>
                 <constraint firstItem="aNh-rH-2Mj" firstAttribute="top" secondItem="81a-ky-7bD" secondAttribute="bottom" id="VW0-3y-UUs"/>
                 <constraint firstItem="92R-aw-5CZ" firstAttribute="leading" secondItem="e7e-0V-rYM" secondAttribute="leading" id="Wnh-rn-Pou"/>
@@ -477,6 +496,7 @@
                 <constraint firstItem="XLw-Xr-akL" firstAttribute="leading" secondItem="e7e-0V-rYM" secondAttribute="leading" id="eU1-Qf-Nb2"/>
                 <constraint firstItem="e5D-yU-MNC" firstAttribute="centerY" secondItem="eJK-yj-IVB" secondAttribute="centerY" id="edt-AG-HCH"/>
                 <constraint firstItem="OVe-gJ-LZa" firstAttribute="centerY" secondItem="oWL-Xy-LvL" secondAttribute="centerY" id="eeA-D4-GWA"/>
+                <constraint firstItem="PR6-3d-8vK" firstAttribute="centerX" secondItem="eJK-yj-IVB" secondAttribute="centerX" constant="24" id="ffz-79-kf9"/>
                 <constraint firstItem="cqL-FH-5V7" firstAttribute="leading" secondItem="e7e-0V-rYM" secondAttribute="leading" id="gAU-gx-ZwV"/>
                 <constraint firstItem="e7e-0V-rYM" firstAttribute="bottom" secondItem="cqL-FH-5V7" secondAttribute="bottom" id="hD0-fo-UxD"/>
                 <constraint firstItem="e7e-0V-rYM" firstAttribute="trailing" secondItem="iiz-Hc-GK4" secondAttribute="trailing" constant="20" id="nSE-WJ-oMg"/>
@@ -519,6 +539,7 @@
                 <outlet property="pingResultLabel" destination="oh4-SD-lOB" id="nz4-E3-Ho8"/>
                 <outlet property="progressGaugePlaceholderView" destination="OVe-gJ-LZa" id="aHx-1i-3b9"/>
                 <outlet property="progressLabel" destination="oWL-Xy-LvL" id="h3P-w0-iB7"/>
+                <outlet property="qosProgressLabelContainer" destination="PR6-3d-8vK" id="oVw-N6-TYc"/>
                 <outlet property="qosProgressView" destination="Y5P-9h-OrJ" id="JdA-ih-V65"/>
                 <outlet property="rootGaugeView" destination="iiz-Hc-GK4" id="aAN-iG-PHW"/>
                 <outlet property="speedGaugePlaceholderView" destination="eJK-yj-IVB" id="X8b-LT-v8s"/>

--- a/Sources/Test/View/RMBTTestPortraitView.xib
+++ b/Sources/Test/View/RMBTTestPortraitView.xib
@@ -105,15 +105,15 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PR6-3d-8vK">
-                    <rect key="frame" x="85.5" y="399.5" width="147.5" height="75"/>
+                    <rect key="frame" x="105.5" y="414.5" width="116" height="45"/>
                     <subviews>
-                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="43e-6e-tGj">
-                            <rect key="frame" x="0.0" y="27.5" width="20" height="20"/>
+                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="43e-6e-tGj">
+                            <rect key="frame" x="0.0" y="4" width="37" height="37"/>
                             <color key="color" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </activityIndicatorView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="QoS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e76-bN-8pV">
-                            <rect key="frame" x="28" y="0.0" width="119.5" height="75"/>
-                            <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="64"/>
+                            <rect key="frame" x="45" y="0.0" width="71" height="45"/>
+                            <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="38"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
@@ -496,7 +496,7 @@
                 <constraint firstItem="XLw-Xr-akL" firstAttribute="leading" secondItem="e7e-0V-rYM" secondAttribute="leading" id="eU1-Qf-Nb2"/>
                 <constraint firstItem="e5D-yU-MNC" firstAttribute="centerY" secondItem="eJK-yj-IVB" secondAttribute="centerY" id="edt-AG-HCH"/>
                 <constraint firstItem="OVe-gJ-LZa" firstAttribute="centerY" secondItem="oWL-Xy-LvL" secondAttribute="centerY" id="eeA-D4-GWA"/>
-                <constraint firstItem="PR6-3d-8vK" firstAttribute="centerX" secondItem="eJK-yj-IVB" secondAttribute="centerX" constant="24" id="ffz-79-kf9"/>
+                <constraint firstItem="PR6-3d-8vK" firstAttribute="centerX" secondItem="eJK-yj-IVB" secondAttribute="centerX" constant="28" id="ffz-79-kf9"/>
                 <constraint firstItem="cqL-FH-5V7" firstAttribute="leading" secondItem="e7e-0V-rYM" secondAttribute="leading" id="gAU-gx-ZwV"/>
                 <constraint firstItem="e7e-0V-rYM" firstAttribute="bottom" secondItem="cqL-FH-5V7" secondAttribute="bottom" id="hD0-fo-UxD"/>
                 <constraint firstItem="e7e-0V-rYM" firstAttribute="trailing" secondItem="iiz-Hc-GK4" secondAttribute="trailing" constant="20" id="nSE-WJ-oMg"/>


### PR DESCRIPTION
This PR improves QoS activity indication by displaying a spinner and "QoS" label when the QoS phase of the test becomes active.

![Simulator Screenshot - iPhone 15 - 2024-02-19 at 10 50 58](https://github.com/rtr-nettest/open-rmbt-ios/assets/244850/2fe4310a-1cde-48af-857e-c966d6139b47)
