### PR TITLE
Do not display Network name during the Test when the name is not available

### DIFF
--- a/Sources/Test/RMBTTestViewController.swift
+++ b/Sources/Test/RMBTTestViewController.swift
@@ -655,7 +655,7 @@ extension RMBTTestViewController: UIViewControllerTransitioningDelegate {
 
 extension RMBTTestViewController: RMBTBaseTestViewControllerSubclass {
     func onTestUpdatedConnectivity(_ connectivity: RMBTConnectivity) {
-        self.networkName = RMBTValueOrString(connectivity.networkName, "Unknown") as? String
+        self.networkName = connectivity.networkName
         self.networkType = RMBTValueOrString(connectivity.networkTypeDescription, "n/a") as? String ?? ""
         
         if (connectivity.networkType == .cellular) {

--- a/Sources/Test/View/RMBTTestLandscapeView.xib
+++ b/Sources/Test/View/RMBTTestLandscapeView.xib
@@ -113,7 +113,7 @@
                             <color key="color" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </activityIndicatorView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="QoS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6kE-hk-ZNV">
-                            <rect key="frame" x="44.999999999999986" y="0.0" width="71" height="44.666666666666664"/>
+                            <rect key="frame" x="44.999999999999986" y="0.0" width="71.000000000000014" height="44.666666666666664"/>
                             <fontDescription key="fontDescription" name="Roboto-Medium" family="Roboto" pointSize="38"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
@@ -536,6 +536,7 @@
                 <outlet property="loopModeWaitingView" destination="2WG-qA-mjh" id="CHB-9E-v5N"/>
                 <outlet property="networkMobileImageView" destination="aI8-eO-atQ" id="dd0-lZ-utB"/>
                 <outlet property="networkNameLabel" destination="aNh-rH-2Mj" id="kUV-gX-7kw"/>
+                <outlet property="networkNameTitleLabel" destination="81a-ky-7bD" id="7fX-xB-b7q"/>
                 <outlet property="networkTechnologyImageView" destination="apV-CG-0ul" id="Uan-9H-hk6"/>
                 <outlet property="networkTypeImageView" destination="0NP-Sa-HQI" id="3SQ-OI-V1a"/>
                 <outlet property="pingGraphView" destination="uSZ-4Y-LuH" id="ZtH-WZ-Vyo"/>

--- a/Sources/Test/View/RMBTTestPortraitView.swift
+++ b/Sources/Test/View/RMBTTestPortraitView.swift
@@ -30,6 +30,7 @@ class RMBTTestPortraitView: UIView, XibLoadable {
     @IBOutlet weak var technologyTitleLabel: UILabel!
     @IBOutlet weak var technologyValueLabel: UILabel!
     @IBOutlet weak var networkTypeLabel: UILabel?
+    @IBOutlet weak var networkNameTitleLabel: UILabel!
     @IBOutlet weak var networkNameLabel: UILabel!
     @IBOutlet weak var networkTypeImageView: UIImageView!
     
@@ -97,6 +98,7 @@ class RMBTTestPortraitView: UIView, XibLoadable {
     var networkName: String? {
         didSet {
             self.networkNameLabel.text = networkName
+            self.networkNameTitleLabel.isHidden = (networkName?.isEmpty ?? true)
         }
     }
     

--- a/Sources/Test/View/RMBTTestPortraitView.xib
+++ b/Sources/Test/View/RMBTTestPortraitView.xib
@@ -531,6 +531,7 @@
                 <outlet property="loopModeWaitingView" destination="2WG-qA-mjh" id="CHB-9E-v5N"/>
                 <outlet property="networkMobileImageView" destination="Hbn-C8-ttA" id="Z2X-QW-1CG"/>
                 <outlet property="networkNameLabel" destination="aNh-rH-2Mj" id="kUV-gX-7kw"/>
+                <outlet property="networkNameTitleLabel" destination="81a-ky-7bD" id="r3D-m4-ovu"/>
                 <outlet property="networkTechnologyImageView" destination="pjb-pX-akO" id="FlS-6w-EL0"/>
                 <outlet property="networkTypeImageView" destination="0NP-Sa-HQI" id="3SQ-OI-V1a"/>
                 <outlet property="offsetGaugesConstraint" destination="JME-Ib-bNk" id="s8m-hD-bVx"/>


### PR DESCRIPTION
This PR removes Network labels from Test screen when the network name is not available (e.g. when we are on cellular network)

![IMG_718318E68EC9-1](https://github.com/rtr-nettest/open-rmbt-ios/assets/244850/75ee9aaf-8e1b-49ed-86de-9809830f2ba6)
