### PR TITLE
Update project default setting

### DIFF
--- a/Sources/RMBTSettings.swift
+++ b/Sources/RMBTSettings.swift
@@ -82,8 +82,8 @@ import Foundation
     ///
     @objc public dynamic var debugLoopModeMinDelay: UInt = 0
     
-    @objc public dynamic var qosEnabled: Bool = true
-    @objc public dynamic var only2Hours: Bool = true
+    @objc public dynamic var qosEnabled: Bool = false
+    @objc public dynamic var only2Hours: Bool = false
     @objc public dynamic var previousLaunchQoSDate: Date?
     
     

--- a/public/Configurations/Configs/RMBTConfig.swift
+++ b/public/Configurations/Configs/RMBTConfig.swift
@@ -39,16 +39,16 @@ public class RMBTConfig {
     static let DEACTIVATE_DEV_CODE = "00000000"
     
     static let RMBT_TEST_LOOPMODE_MIN_COUNT = 1
-    static let RMBT_TEST_LOOPMODE_DEFAULT_COUNT = 10
-    static let RMBT_TEST_LOOPMODE_MAX_COUNT = 100
+    static let RMBT_TEST_LOOPMODE_DEFAULT_COUNT = 50
+    static let RMBT_TEST_LOOPMODE_MAX_COUNT = 500
 
     // Minimum/maximum number of minutes that user can choose to wait before next test is started:
     static let RMBT_TEST_LOOPMODE_MIN_DELAY_MINS = 5
-    static let RMBT_TEST_LOOPMODE_DEFAULT_DELAY_MINS = 10
+    static let RMBT_TEST_LOOPMODE_DEFAULT_DELAY_MINS = 15
     static let RMBT_TEST_LOOPMODE_MAX_DELAY_MINS = (24 * 60) // one day
 
     // ... meters user locations must change before next test is started:
-    static let RMBT_TEST_LOOPMODE_MIN_MOVEMENT_M = 50
+    static let RMBT_TEST_LOOPMODE_MIN_MOVEMENT_M = 25
     static let RMBT_TEST_LOOPMODE_DEFAULT_MOVEMENT_M = 250
     static let RMBT_TEST_LOOPMODE_MAX_MOVEMENT_M = 10000
     


### PR DESCRIPTION
This PR updates default settings:

Default time between loop measurments: 15
Miniumum time between loop measurements: 5
Default number of loop measurements 50: (was 10)
Maximum number of loop measurements 500 (was 100)
Minumum distance between loop measurements: 25

QoS measurements: Disabled by default
QoS measurements only after 2h: Disabled by default