### PR TITLE
Fix migrating UUID to different devices

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -18,6 +18,7 @@ target 'RMBT' do
   
   pod 'libextobjc/EXTKeyPathCoding'
   pod 'TUSafariActivity'
+  pod 'KeychainAccess'
 
   
 #  if File.exist?(File.expand_path('../Vendor/CocoaAsyncSocket', __FILE__))

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,6 +13,7 @@ PODS:
     - BlocksKit/Core
     - BlocksKit/DynamicDelegate
   - CocoaAsyncSocket (7.6.5)
+  - KeychainAccess (4.2.2)
   - libextobjc/EXTKeyPathCoding (0.6):
     - libextobjc/RuntimeExtensions
   - libextobjc/RuntimeExtensions (0.6)
@@ -50,6 +51,7 @@ DEPENDENCIES:
   - BlocksKit/MessageUI (from `https://github.com/sglushchenko/BlocksKit`, branch `without_UIWebView`)
   - BlocksKit/UIKit (from `https://github.com/sglushchenko/BlocksKit`, branch `without_UIWebView`)
   - CocoaAsyncSocket
+  - KeychainAccess
   - libextobjc/EXTKeyPathCoding
   - "MaterialComponents/Tabs+TabBarView"
   - ReachabilitySwift
@@ -62,6 +64,7 @@ SPEC REPOS:
     - AlamofireObjectMapper
     - BCGenieEffect
     - CocoaAsyncSocket
+    - KeychainAccess
     - libextobjc
     - MaterialComponents
     - MDFInternationalization
@@ -87,6 +90,7 @@ SPEC CHECKSUMS:
   BCGenieEffect: 3efb235716f121caa6b26040bfd0ae11e1bae4b4
   BlocksKit: 5fae06c13638d9fdb0bbddca3dabfe8f5aa735c5
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
+  KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   libextobjc: aed8b7d2b07f511c1a7ecaacb33ea03e327c69b7
   MaterialComponents: 1a9b2d9d45b1601ae544de85089adc4c464306d4
   MDFInternationalization: d697c55307816222a55685c4ccb1044ffb030c12
@@ -96,6 +100,6 @@ SPEC CHECKSUMS:
   TUSafariActivity: afc55a00965377939107ce4fdc7f951f62454546
   XCGLogger: 1943831ef907df55108b0b18657953f868de973b
 
-PODFILE CHECKSUM: 9ab30efa7798a1a19278168e22ee7d8a7ffc99f3
+PODFILE CHECKSUM: 27dac78395e8bfd9da390d0256ff1d40705acc8a
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/RMBT.xcodeproj/project.pbxproj
+++ b/RMBT.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		36B75A27273EA096006F4CB3 /* RMBTHistoryLoopCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 36B75A26273EA096006F4CB3 /* RMBTHistoryLoopCell.xib */; };
 		36B75A29273EA73C006F4CB3 /* RMBTHistoryLoopCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B75A28273EA73C006F4CB3 /* RMBTHistoryLoopCell.swift */; };
 		494998E32B7E353C0067B3D8 /* TopPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494998E22B7E353C0067B3D8 /* TopPopoverView.swift */; };
+		49B28C762BA09D6A00697BB4 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B28C752BA09D6A00697BB4 /* Keychain.swift */; };
 		49F976802B0B3E880098C4CC /* RMBTConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C86FDC2AFBBF1500663CE2 /* RMBTConfig.swift */; };
 		C573F2A5175281D300C728FC /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C573F2A4175281D300C728FC /* MapKit.framework */; };
 		C573F2B1175294A500C728FC /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C573F2B0175294A500C728FC /* CoreLocation.framework */; };
@@ -316,6 +317,7 @@
 		36B75A26273EA096006F4CB3 /* RMBTHistoryLoopCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RMBTHistoryLoopCell.xib; sourceTree = "<group>"; };
 		36B75A28273EA73C006F4CB3 /* RMBTHistoryLoopCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RMBTHistoryLoopCell.swift; sourceTree = "<group>"; };
 		494998E22B7E353C0067B3D8 /* TopPopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPopoverView.swift; sourceTree = "<group>"; };
+		49B28C752BA09D6A00697BB4 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		49C86FDC2AFBBF1500663CE2 /* RMBTConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RMBTConfig.swift; sourceTree = "<group>"; };
 		89CA21386C488DD817CA1DC2 /* Pods-RMBT.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RMBT.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RMBT/Pods-RMBT.debug.xcconfig"; sourceTree = "<group>"; };
 		C573F2A4175281D300C728FC /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
@@ -797,6 +799,7 @@
 				E9400F1C26BE87450067273A /* ObjectMapperHelper.swift */,
 				E9400F3826BE8D840067273A /* Speed.swift */,
 				E94ED1CE26C3C22F00B17B25 /* NetworkReachability.swift */,
+				49B28C752BA09D6A00697BB4 /* Keychain.swift */,
 			);
 			name = _Utility;
 			sourceTree = "<group>";
@@ -1700,6 +1703,7 @@
 				E9400F0426BAD0CE0067273A /* BasicRequestBuilder_iOS.swift in Sources */,
 				E94EC06B276E038800DB0B21 /* RMBTMapOptions.swift in Sources */,
 				E9400EE526BA32150067273A /* LogConfig.swift in Sources */,
+				49B28C762BA09D6A00697BB4 /* Keychain.swift in Sources */,
 				E95954AF26E602EC004EA6D9 /* RMBTHistoryFilter2ViewController.swift in Sources */,
 				E9AA0DE127634EF1003C71D7 /* RMBTQoSDNSTest.swift in Sources */,
 				E91316AE26AD72F200368DCD /* RMBTTOSViewController.swift in Sources */,

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -1,0 +1,42 @@
+//
+//  Keychain.swift
+//  RMBT
+//
+//  Created by Jiri Urbasek on 3/12/24.
+//  Copyright © 2024 appscape gmbh. All rights reserved.
+//
+
+import Foundation
+import KeychainAccess
+
+final class KeychainHelper {
+    private static let uuidKeychain = Keychain(service: "at.netztest.app.ios.keychain").accessibility(.whenUnlockedThisDeviceOnly)
+
+    public class func clearStoredUUID(uuidKey: String?) {
+        if let uuidKey {
+            try? uuidKeychain.remove(uuidKey)
+        }
+    }
+
+    public class func storeNewUUID(uuidKey: String, uuid: String) {
+        try? uuidKeychain.set(uuid, key: uuidKey)
+    }
+
+    public class func checkStoredUUID(uuidKey: String) -> String? {
+        let unsecureUUID = UserDefaults.appDefaults.object(forKey: uuidKey) as? String
+        if let unsecureUUID {
+            storeNewUUID(uuidKey: uuidKey, uuid: unsecureUUID)
+            UserDefaults.clearStoredUUID(uuidKey: uuidKey)
+        }
+        return unsecureUUID ?? (try? uuidKeychain.getString(uuidKey))
+    }
+}
+
+private extension UserDefaults {
+    class func clearStoredUUID(uuidKey: String?) {
+        if let uuidKey = uuidKey {
+            UserDefaults.appDefaults.removeObject(forKey: uuidKey)
+            UserDefaults.appDefaults.synchronize()
+        }
+    }
+}

--- a/Sources/RMBTControlServer.swift
+++ b/Sources/RMBTControlServer.swift
@@ -80,7 +80,7 @@ extension RMBTControlServer {
                     
                     // save uuid
                     if let uuidKey = self.uuidKey, let u = self.uuid {
-                        UserDefaults.storeNewUUID(uuidKey: uuidKey, uuid: u)
+                        KeychainHelper.storeNewUUID(uuidKey: uuidKey, uuid: u)
                     }
                     
                     // get history filters
@@ -168,7 +168,7 @@ extension RMBTControlServer {
 
         if self.uuid == nil,
             let key = uuidKey {
-            uuid = UserDefaults.checkStoredUUID(uuidKey: key)
+            uuid = KeychainHelper.checkStoredUUID(uuidKey: key)
         }
         
         Log.logger.info("Control Server base url = \(self.baseUrl)")
@@ -479,7 +479,7 @@ extension RMBTControlServer {
         baseUrl = RMBTConfig.shared.RMBT_CONTROL_SERVER_URL
         uuidKey = "\(storeUUIDKey)\(URL(string: baseUrl)!.host!)"
         
-        UserDefaults.clearStoredUUID(uuidKey: uuidKey)
+        KeychainHelper.clearStoredUUID(uuidKey: uuidKey)
         self.uuid = nil
     }
     

--- a/Sources/UserDefaults+Additions.swift
+++ b/Sources/UserDefaults+Additions.swift
@@ -86,25 +86,6 @@ extension UserDefaults {
         
         return user
     }
-    
-    public class func clearStoredUUID(uuidKey: String?) {
-        if let uuidKey = uuidKey {
-            UserDefaults.appDefaults.removeObject(forKey: uuidKey)
-            UserDefaults.appDefaults.synchronize()
-        }
-    }
-    ///
-    public class func storeNewUUID(uuidKey: String, uuid: String) {
-        if RMBTSettings.shared.isClientPersistent {
-            storeDataFor(key: uuidKey, obj: uuid)
-            Log.logger.debug("UUID: uuid is now: \(uuid) for key '\(uuidKey)'")
-        }
-    }
-    
-    ///
-    public class func checkStoredUUID(uuidKey: String) -> String? {
-        return UserDefaults.appDefaults.object(forKey: uuidKey) as? String
-    }
 }
 
 extension UserDefaults {


### PR DESCRIPTION
This PR fixes the issue that users' UUID could be migrated to different devices.

It fixes it by storing the UUID in Keychain with accessibility "thisDeviceOnly" instead of UserDefaults (which by default gets copied to different devices)