### PR TITLE
Fix incorrect WLAN name on History Result screen

### DIFF
--- a/Sources/History/RMBTHistoryResultViewController.swift
+++ b/Sources/History/RMBTHistoryResultViewController.swift
@@ -278,9 +278,7 @@ extension RMBTHistoryResultViewController: UITableViewDelegate, UITableViewDataS
             return mapCell
         case .network:
             let networkCell = tableView.dequeueReusableCell(withIdentifier: RMBTHistoryNetworkCell.ID, for: indexPath) as! RMBTHistoryNetworkCell
-            networkCell.networkName = historyResult.netItems.first(where: { item in
-                item.title == "WLAN SSID" || item.title == NSLocalizedString("history.result.operator", comment: "");
-            })?.value
+            networkCell.networkName = historyResult.wlanSSID
             networkCell.networkType = historyResult.networkTypeServerDescription
             networkCell.selectionStyle = .none
             return networkCell

--- a/Sources/Responses/SpeedMeasurementResultResponse.swift
+++ b/Sources/Responses/SpeedMeasurementResultResponse.swift
@@ -242,14 +242,17 @@ public class SpeedMeasurementResultResponse: BasicResponse {
 
     open class NetworkInfo: Mappable {
         open var networkTypeLabel: String?
-        
         open var providerName: String?
-        
+        open var wifiSSID: String?
+        open var roamingTypeLabel: String?
+
         public required init?(map: Map) { }
         
         public func mapping(map: Map) {
             networkTypeLabel <- map["network_type_label"]
             providerName <- map["provider_name"]
+            wifiSSID <- map["wifi_ssid"]
+            roamingTypeLabel <- map["roaming_type_label"]
         }
     }
     ///


### PR DESCRIPTION
Choose wlan name based on the responses' "network_info" object, not the "net" object