### PR TITLE
Display Ping Chart as a bar chart

### DIFF
--- a/Sources/RMBTBaseTestViewController.swift
+++ b/Sources/RMBTBaseTestViewController.swift
@@ -23,6 +23,7 @@ protocol RMBTBaseTestViewControllerSubclass: AnyObject {
 
     func onTestMeasuredLatency(_ nanos: UInt64)
     func onTestMeasuredPings(_ pings: [Ping], in phase: RMBTTestRunnerPhase)
+    func onTestCompletedLantencPhase()
     func onTestMeasuredTroughputs(_ throughputs: [RMBTThroughput], in phase: RMBTTestRunnerPhase)
 
     func onTestMeasuredDownloadSpeed(_ kbps: UInt32)
@@ -259,7 +260,12 @@ extension RMBTBaseTestViewController: RMBTTestRunnerDelegate {
         guard let subself = self as? RMBTBaseTestViewControllerSubclass else { return }
         subself.onTestMeasuredPings(pings, in: phase)
     }
-    
+
+    func testRunnerDidCompleteLatencyPhase() {
+        guard let subself = self as? RMBTBaseTestViewControllerSubclass else { return }
+        subself.onTestCompletedLantencPhase()
+    }
+
     func testRunnerDidMeasureThroughputs(_ throughputs: [RMBTThroughput], in phase: RMBTTestRunnerPhase) {
         guard let subself = self as? RMBTBaseTestViewControllerSubclass else { return }
         subself.onTestMeasuredTroughputs(throughputs, in: phase)

--- a/Sources/RMBTTestRunner.swift
+++ b/Sources/RMBTTestRunner.swift
@@ -41,6 +41,7 @@ protocol RMBTTestRunnerDelegate: AnyObject {
     /// progress from 0.0 to 1.0
     func testRunnerDidUpdateProgress(_ progress: Float, in phase: RMBTTestRunnerPhase)
     func testRunnerDidMeasurePings(_ pings: [Ping], in phase: RMBTTestRunnerPhase)
+    func testRunnerDidCompleteLatencyPhase()
     func testRunnerDidMeasureThroughputs(_ throughputs: [RMBTThroughput], in phase: RMBTTestRunnerPhase)
 
     /// These delegate methods will be called even before the test starts
@@ -686,8 +687,12 @@ extension RMBTTestRunner: RMBTTestWorkerDelegate {
         assert(phase == .latency, "Invalid state")
         assert(!dead, "Invalid state")
 
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            self.delegate?.testRunnerDidCompleteLatencyPhase()
+        }
+
         if (self.markWorkerAsFinished()) {
-            workerQueue.asyncAfter(deadline: .now() + 0.3) {
+            workerQueue.asyncAfter(deadline: .now() + 1.2) {
                 self.startPhase(.down, withAllWorkers: true, performingSelector: #selector(RMBTTestWorker.startDownlinkTest), expectedDuration: self.testParams?.testDuration ?? 0, completion: nil)
             }
         }

--- a/Sources/Test/RMBTTestViewController.swift
+++ b/Sources/Test/RMBTTestViewController.swift
@@ -153,8 +153,8 @@ final class RMBTTestViewController: RMBTBaseTestViewController {
         }
     }()
     
-    var delayForGraph: TimeInterval = 1.0
-    var delayForPingGraph: TimeInterval = 0.3
+    var delayForGraph: TimeInterval = 0.5
+    var delayForPingGraph: TimeInterval = 0.0
     var startSpeedPhaseDate: Date = Date()
 
     weak var graphTickTimer: Timer? {
@@ -733,6 +733,10 @@ extension RMBTTestViewController: RMBTBaseTestViewControllerSubclass {
         }
     }
     
+    func onTestCompletedLantencPhase() {
+        currentView.pingGraphView.isHidden = false
+    }
+
     func onTestMeasuredTroughputs(_ throughputs: [RMBTThroughput], in phase: RMBTTestRunnerPhase) {
         var kbps = 0
         var l: Double = 0.0

--- a/Sources/Test/View/RMBTTestPortraitView.swift
+++ b/Sources/Test/View/RMBTTestPortraitView.swift
@@ -404,7 +404,7 @@ class RMBTTestPortraitView: UIView, XibLoadable {
             self.speedGraphView.isHidden = true
         }
         
-        self.pingGraphView.isHidden = phase != .latency
+        self.pingGraphView.isHidden = true
         self.updateDetailInfoView()
     }
     
@@ -428,6 +428,8 @@ class RMBTTestPortraitView: UIView, XibLoadable {
         self.infoView.layer.shadowRadius = 3
         
         self.networkMobileImageView.image = self.networkMobileImageView.image?.withRenderingMode(.alwaysTemplate)
+
+        pingGraphView.showBarChart = true
     }
     
     func updateGaugesPosition() {


### PR DESCRIPTION
This PR updates the chart for Ping during the Test.
It shows the chart when the Ping phase is finished, for 1 secs, then begins the Download chart.
It changes the ping to be bar chart instead of a line chart.

The reason for this logic is that we wanted to display Ping as bar chart but when bars were accumulating during the ping phase progress, it didn't look good. That's why it was decided to display the Ping chart only after all Ping values are available.