### PR TITLE
Add Export buttons to History Index

### DIFF
--- a/Resources/Base.lproj/Localizable.strings
+++ b/Resources/Base.lproj/Localizable.strings
@@ -430,3 +430,5 @@
 "text_ip_address_not_available" = "Address is not available";
 "start_test_button_help_message" = "Press the button to start the test now!";
 "RTR-NetTest" = "RTR-NetTest";
+
+"Export data" = "Export";

--- a/Resources/de.lproj/Localizable.strings
+++ b/Resources/de.lproj/Localizable.strings
@@ -442,3 +442,5 @@
 "text_ip_address_not_available" = "Die Adresse nicht verfügbar";
 "start_test_button_help_message" = "Drücken Sie den Knopf um den Test zu starten";
 "RTR-NetTest" = "RTR-Netztest";
+
+"Export data" = "Exportieren";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -442,3 +442,5 @@
 "text_ip_address_not_available" = "Address is not available";
 "start_test_button_help_message" = "Press the button to start the test now!";
 "RTR-NetTest" = "RTR-NetTest";
+
+"Export data" = "Export";

--- a/Sources/History/Cells/RMBTTestExportCell.swift
+++ b/Sources/History/Cells/RMBTTestExportCell.swift
@@ -67,7 +67,7 @@ class RMBTTestExportCell: UITableViewCell {
             $0.0.configuration?.contentInsets = .init(top: 4, leading: 8, bottom: 4, trailing: 8)
             $0.0.configuration?.title = $0.1.uppercased()
             $0.0.configuration?.image = .init(named: "filetype-\($0.1)-icon")
-            $0.0.accessibilityLabel = NSLocalizedString("Export to", comment: "") + " \($0.1)" // TODO: localize
+            $0.0.accessibilityLabel = NSLocalizedString("Export data", comment: "") + " \($0.1)"
         }
     }
 

--- a/Sources/History/Cells/RMBTTestExportCell.swift
+++ b/Sources/History/Cells/RMBTTestExportCell.swift
@@ -9,9 +9,9 @@
 import UIKit
 
 protocol TestExporting {
-    func exportPDF(openTestUUID: String) async throws -> URL
-    func exportXLSX(openTestUUID: String) async throws -> URL
-    func exportCSV(openTestUUID: String) async throws -> URL
+    func exportPDF(openTestUUIDs: [String]) async throws -> URL
+    func exportXLSX(openTestUUIDs: [String]) async throws -> URL
+    func exportCSV(openTestUUIDs: [String]) async throws -> URL
 }
 
 class RMBTTestExportCell: UITableViewCell {
@@ -28,7 +28,7 @@ class RMBTTestExportCell: UITableViewCell {
     @IBOutlet weak var xlsxButton: UIButton!
     @IBOutlet weak var csvButton: UIButton!
 
-    private var openTestUUID: String?
+    private var openTestUUIDs: [String] = []
     private let exportService: TestExporting = RMBTControlServer.shared
     private var onExportedPDFFile: ((URL) -> Void)?
     private var onExportedXLSXFile: ((URL) -> Void)?
@@ -36,13 +36,13 @@ class RMBTTestExportCell: UITableViewCell {
     private var onFailure: ((Failure) -> Void)?
 
     func configure(
-        with openTestUUID: String,
+        with openTestUUIDs: [String],
         onExportedPDFFile: @escaping ((URL) -> Void),
         onExportedXLSXFile: @escaping  ((URL) -> Void),
         onExportedCSVFile: @escaping ((URL) -> Void),
         onFailure: ((Failure) -> Void)?
     ) {
-        self.openTestUUID = openTestUUID
+        self.openTestUUIDs = openTestUUIDs
         self.onExportedPDFFile = onExportedPDFFile
         self.onExportedXLSXFile = onExportedXLSXFile
         self.onExportedCSVFile = onExportedCSVFile
@@ -72,7 +72,7 @@ class RMBTTestExportCell: UITableViewCell {
     }
 
     @IBAction func pdfButtonTouched(_ sender: UIButton) {
-        guard let openTestUUID else {
+        guard !openTestUUIDs.isEmpty else {
             onFailure?(.missingOpenTestUUID)
             return
         }
@@ -80,7 +80,7 @@ class RMBTTestExportCell: UITableViewCell {
 
         Task { @MainActor in
             do {
-                let pdf = try await exportService.exportPDF(openTestUUID: openTestUUID)
+                let pdf = try await exportService.exportPDF(openTestUUIDs: openTestUUIDs)
                 onExportedPDFFile?(pdf)
             } catch {
                 onFailure?(.exportError(error))
@@ -90,7 +90,7 @@ class RMBTTestExportCell: UITableViewCell {
     }
 
     @IBAction func xlsxButtonTouched(_ sender: UIButton) {
-        guard let openTestUUID else {
+        guard !openTestUUIDs.isEmpty else {
             onFailure?(.missingOpenTestUUID)
             return
         }
@@ -98,7 +98,7 @@ class RMBTTestExportCell: UITableViewCell {
 
         Task { @MainActor in
             do {
-                let pdf = try await exportService.exportXLSX(openTestUUID: openTestUUID)
+                let pdf = try await exportService.exportXLSX(openTestUUIDs: openTestUUIDs)
                 onExportedXLSXFile?(pdf)
             } catch {
                 onFailure?(.exportError(error))
@@ -108,7 +108,7 @@ class RMBTTestExportCell: UITableViewCell {
     }
 
     @IBAction func csvButtonTouched(_ sender: UIButton) {
-        guard let openTestUUID else {
+        guard !openTestUUIDs.isEmpty else {
             onFailure?(.missingOpenTestUUID)
             return
         }
@@ -116,7 +116,7 @@ class RMBTTestExportCell: UITableViewCell {
 
         Task { @MainActor in
             do {
-                let pdf = try await exportService.exportCSV(openTestUUID: openTestUUID)
+                let pdf = try await exportService.exportCSV(openTestUUIDs: openTestUUIDs)
                 onExportedCSVFile?(pdf)
             } catch {
                 onFailure?(.exportError(error))
@@ -142,15 +142,15 @@ private extension UIButton {
 }
 
 extension RMBTControlServer: TestExporting {
-    func exportPDF(openTestUUID: String) async throws -> URL {
-        try await getTestExport(into: .pdf, openTestUUID: openTestUUID)
+    func exportPDF(openTestUUIDs: [String]) async throws -> URL {
+        try await getTestExport(into: .pdf, openTestUUIDs: openTestUUIDs)
     }
 
-    func exportXLSX(openTestUUID: String) async throws -> URL {
-        try await getTestExport(into: .xlsx, openTestUUID: openTestUUID)
+    func exportXLSX(openTestUUIDs: [String]) async throws -> URL {
+        try await getTestExport(into: .xlsx, openTestUUIDs: openTestUUIDs)
     }
 
-    func exportCSV(openTestUUID: String) async throws -> URL {
-        try await getTestExport(into: .csv, openTestUUID: openTestUUID)
+    func exportCSV(openTestUUIDs: [String]) async throws -> URL {
+        try await getTestExport(into: .csv, openTestUUIDs: openTestUUIDs)
     }
 }

--- a/Sources/History/RMBTHistoryIndexViewController.swift
+++ b/Sources/History/RMBTHistoryIndexViewController.swift
@@ -349,7 +349,7 @@ extension RMBTHistoryIndexViewController: UITableViewDataSource, UITableViewDele
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         if section == testResults.count && !testResults.isEmpty {
-            return 44
+            return 56
         }
         guard section < testResults.count, testResults[section].loopResults.count > 1 else {
             return 0

--- a/Sources/History/RMBTHistoryIndexViewController.swift
+++ b/Sources/History/RMBTHistoryIndexViewController.swift
@@ -110,6 +110,8 @@ final class RMBTHistoryIndexViewController: UIViewController {
         self.tableView.register(UINib(nibName: RMBTHistoryIndexCell.ID, bundle: nil), forCellReuseIdentifier: RMBTHistoryIndexCell.ID)
         self.tableView.register(UINib(nibName: RMBTHistoryLoadingCell.ID, bundle: nil), forCellReuseIdentifier: RMBTHistoryLoadingCell.ID)
         self.tableView.register(UINib(nibName: RMBTHistoryLoopCell.ID, bundle: nil), forHeaderFooterViewReuseIdentifier: RMBTHistoryLoopCell.ID)
+        self.tableView.register(UINib(nibName: RMBTHistoryTitleCell.ID, bundle: nil), forCellReuseIdentifier: RMBTHistoryTitleCell.ID)
+        self.tableView.register(UINib(nibName: RMBTTestExportCell.ID, bundle: nil), forCellReuseIdentifier: RMBTTestExportCell.ID)
         self.tableView.refreshControl = UIRefreshControl()
         self.tableView.refreshControl?.addTarget(self, action: #selector(refreshFromTableView(_:)), for: .valueChanged)
         if #available(iOS 15.0, *) {
@@ -333,7 +335,7 @@ final class RMBTHistoryIndexViewController: UIViewController {
 
 extension RMBTHistoryIndexViewController: UITableViewDataSource, UITableViewDelegate {
     func numberOfSections(in tableView: UITableView) -> Int {
-        var result = testResults.count
+        var result = testResults.count + 1
         if (nextBatchIndex != NSNotFound) { result += 1 }
         return result
     }
@@ -346,6 +348,9 @@ extension RMBTHistoryIndexViewController: UITableViewDataSource, UITableViewDele
     }
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if section == testResults.count && !testResults.isEmpty {
+            return 44
+        }
         guard section < testResults.count, testResults[section].loopResults.count > 1 else {
             return 0
         }
@@ -353,6 +358,13 @@ extension RMBTHistoryIndexViewController: UITableViewDataSource, UITableViewDele
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        if section == testResults.count && !testResults.isEmpty {
+            // last headere is "Download" section with export buttons
+            let header = tableView.dequeueReusableCell(withIdentifier: RMBTHistoryTitleCell.ID) as! RMBTHistoryTitleCell
+            header.title = NSLocalizedString("Download", comment: "") // TODO: Localize
+            return header
+        }
+
         guard section < testResults.count, testResults[section].loopResults.count > 1 else {
             return nil
         }
@@ -381,6 +393,9 @@ extension RMBTHistoryIndexViewController: UITableViewDataSource, UITableViewDele
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if indexPath.section == testResults.count && !testResults.isEmpty {
+            return 44
+        }
         guard indexPath.section < testResults.count else {
             return 0
         }
@@ -392,6 +407,23 @@ extension RMBTHistoryIndexViewController: UITableViewDataSource, UITableViewDele
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.section == testResults.count && !testResults.isEmpty {
+            let cell = tableView.dequeueReusableCell(withIdentifier: RMBTTestExportCell.ID, for: indexPath) as! RMBTTestExportCell
+            cell.configure(
+                with: testResults.flatMap(\.openTestUUIDs),
+                onExportedPDFFile: { [weak self] in
+                    self?.openFile(url: $0, asNamed: "all-tests", fileExtension: "pdf")
+                },
+                onExportedXLSXFile: { [weak self] in
+                    self?.openFile(url: $0, asNamed: "all-tests", fileExtension: "xlsx")
+                },
+                onExportedCSVFile: { [weak self] in
+                    self?.openFile(url: $0, asNamed: "all-tests", fileExtension: "csv")
+                },
+                onFailure: nil
+            )
+            return cell
+        }
         if (indexPath.section >= testResults.count) {
             // Loading cell
             let cell = tableView.dequeueReusableCell(withIdentifier: RMBTHistoryLoadingCell.ID, for: indexPath) as! RMBTHistoryLoadingCell
@@ -437,6 +469,21 @@ extension RMBTHistoryIndexViewController: UITableViewDataSource, UITableViewDele
         }
     }
 }
+
+private extension RMBTHistoryIndexViewController {
+    func openFile(url: URL, asNamed name: String, fileExtension: String) {
+        let pdfViewController = RMBTFilePreviewViewController()
+        let fileService = FilePreviewService()
+        if let fileURL = try? fileService.temporarilySave(
+            fileURL: url,
+            withName: name + "." + fileExtension
+        ) {
+            pdfViewController.configure(fileURLs: [fileURL])
+            navigationController?.present(pdfViewController, animated: true)
+        }
+    }
+}
+
 
 // MARK: Localizations
 

--- a/Sources/History/RMBTHistoryIndexViewController.swift
+++ b/Sources/History/RMBTHistoryIndexViewController.swift
@@ -361,7 +361,7 @@ extension RMBTHistoryIndexViewController: UITableViewDataSource, UITableViewDele
         if section == testResults.count && !testResults.isEmpty {
             // last headere is "Download" section with export buttons
             let header = tableView.dequeueReusableCell(withIdentifier: RMBTHistoryTitleCell.ID) as! RMBTHistoryTitleCell
-            header.title = NSLocalizedString("Download", comment: "") // TODO: Localize
+            header.title = NSLocalizedString("Export data", comment: "")
             return header
         }
 

--- a/Sources/History/RMBTHistoryResultViewController.swift
+++ b/Sources/History/RMBTHistoryResultViewController.swift
@@ -351,7 +351,7 @@ extension RMBTHistoryResultViewController: UITableViewDelegate, UITableViewDataS
             let cell = tableView.dequeueReusableCell(withIdentifier: RMBTTestExportCell.ID, for: indexPath) as! RMBTTestExportCell
             if let testUUID = historyResult.openTestUuid {
                 cell.configure(
-                    with: testUUID,
+                    with: [testUUID],
                     onExportedPDFFile: { [weak self] in
                         self?.openFile(url: $0, historyResult: historyResult, testUUID: testUUID, fileExtension: "pdf")
                     },

--- a/Sources/History/RMBTHistoryResultViewController.swift
+++ b/Sources/History/RMBTHistoryResultViewController.swift
@@ -112,7 +112,7 @@ final class RMBTHistoryResultViewController: UIViewController {
         }
 
         if historyResult.openTestUuid != nil {
-            sections.append(.title(NSLocalizedString("Download", comment: ""))) // TODO: Localize
+            sections.append(.title(NSLocalizedString("Export data", comment: "")))
             sections.append(.exportButtons)
         }
 

--- a/Sources/Models/HistoryItem.swift
+++ b/Sources/Models/HistoryItem.swift
@@ -16,6 +16,8 @@ import ObjectMapper
     ///
     public var testUuid: String?
 
+    public var openTestUuid: String?
+
     ///
     public var time: UInt64?
 
@@ -76,6 +78,13 @@ import ObjectMapper
         //
 
         testUuid           <- map["test_uuid"]
+        openTestUuid       <- map["open_test_uuid"]
+
+        if openTestUuid?.lengthOfBytes(using: .utf8) == 37 && (openTestUuid?.hasPrefix("O") ?? false) {
+            // server adds extraneous "O" at the beginning of the actual UUID 
+            openTestUuid?.removeFirst(1)
+        }
+
         time               <- (map["time"], UInt64NSNumberTransformOf)
         timeZone           <- map["time_zone"]
         timeString         <- map["time_string"]

--- a/Sources/RMBTControlServer.swift
+++ b/Sources/RMBTControlServer.swift
@@ -478,7 +478,7 @@ extension RMBTControlServer {
     func getTestExport(into format: TestExportFormat, openTestUUIDs: [String]) async throws -> URL {
         try await URLSession.shared.download(
             for: format.downloadRequest(
-                baseURL: /*statsURL*/URL(string: "https://m-cloud.netztest.at/RMBTStatisticServer")!,
+                baseURL: /*statsURL*/URL(string: "https://m01.netztest.at/RMBTStatisticServer")!,
                 openTestUUIDs: openTestUUIDs,
                 maxResults: min(openTestUUIDs.count, 500)
             )

--- a/Sources/RMBTControlServer.swift
+++ b/Sources/RMBTControlServer.swift
@@ -25,7 +25,8 @@ public typealias HistoryFilterType = [String: [String]]
     
     public var statsURL: URL? = URL(string: RMBTHelpers.RMBTLocalize(urlString: RMBTConfig.RMBT_STATS_URL))
     public var mapServerURL: URL?
-    
+    public var statisticServerURL: URL?
+
     public lazy var termsAndConditions: SettingsResponse.Settings.TermsAndConditions = {
         let settings = SettingsResponse.Settings.TermsAndConditions()
         settings.url = RMBTHelpers.RMBTLocalize(urlString: RMBTConfig.RMBT_PRIVACY_TOS_URL)
@@ -99,7 +100,12 @@ extension RMBTControlServer {
                        let url = URL(string: statistics) {
                         self.statsURL = url
                     }
-                    
+
+                    if let statisticServer = set.urls?.statisticsServer,
+                       let url = URL(string: statisticServer) {
+                        self.statisticServerURL = url
+                    }
+
                     if let mapServer = set.urls?.mapServer,
                        let url = URL(string: mapServer) {
                         self.mapServerURL = url
@@ -478,9 +484,9 @@ extension RMBTControlServer {
     func getTestExport(into format: TestExportFormat, openTestUUIDs: [String]) async throws -> URL {
         try await URLSession.shared.download(
             for: format.downloadRequest(
-                baseURL: /*statsURL*/URL(string: "https://m01.netztest.at/RMBTStatisticServer")!,
+                baseURL: statisticServerURL ?? URL(string: "https://m01.netztest.at/RMBTStatisticServer")!,
                 openTestUUIDs: openTestUUIDs,
-                maxResults: min(openTestUUIDs.count, 500)
+                maxResults: openTestUUIDs.count > 1 ? min(openTestUUIDs.count, 500) : nil
             )
         ).0
     }

--- a/Sources/RMBTControlServer.swift
+++ b/Sources/RMBTControlServer.swift
@@ -475,9 +475,13 @@ extension RMBTControlServer {
         }
     }
 
-    func getTestExport(into format: TestExportFormat, openTestUUID: String) async throws -> URL {
+    func getTestExport(into format: TestExportFormat, openTestUUIDs: [String]) async throws -> URL {
         try await URLSession.shared.download(
-            for: format.downloadRequest(baseURL: /*statsURL*/URL(string: "https://m-cloud.netztest.at/RMBTStatisticServer")!, openTestUUID: openTestUUID)
+            for: format.downloadRequest(
+                baseURL: /*statsURL*/URL(string: "https://m-cloud.netztest.at/RMBTStatisticServer")!,
+                openTestUUIDs: openTestUUIDs,
+                maxResults: min(openTestUUIDs.count, 500)
+            )
         ).0
     }
 

--- a/Sources/RMBTHistoryResult.swift
+++ b/Sources/RMBTHistoryResult.swift
@@ -77,6 +77,7 @@ class RMBTHistoryResult: NSObject {
         // it's a numeric code
         networkTypeServerDescription = response["network_type"] as? String ?? ""
         uuid = response["test_uuid"] as? String ?? ""
+        openTestUuid = response["open_test_uuid"] as? String
         loopUuid = response["loop_uuid"] as? String
         deviceModel = response["model"] as? String
         timeString = response["time_string"] as? String

--- a/Sources/RMBTHistoryResult.swift
+++ b/Sources/RMBTHistoryResult.swift
@@ -28,6 +28,10 @@ class RMBTHistoryLoopResult: RMBTHistoryResult {
         }
         self.loopResults = loopResults
     }
+
+    var openTestUUIDs: [String] {
+        loopResults.compactMap(\.openTestUuid)
+    }
 }
 
 class RMBTHistoryResult: NSObject {

--- a/Sources/Responses/Responses.swift
+++ b/Sources/Responses/Responses.swift
@@ -436,6 +436,7 @@ public class SettingsResponse: BasicResponse {
         class UrlSettings: Mappable {
             var opendataPrefix: String?
             var statistics: String?
+            var statisticsServer: String?
             var mapServer: String?
             
             ///
@@ -469,15 +470,12 @@ public class SettingsResponse: BasicResponse {
             func mapping(map: Map) {
                 opendataPrefix  <- map["open_data_prefix"]
                 statistics      <- map["statistics"]
+                statisticsServer <- map["url_statistic_server"]
                 mapServer      <- map["url_map_server"]
-                
-                
                 ipv4IpOnly     <- map["control_ipv4_only"]
                 ipv6IpOnly     <- map["control_ipv6_only"]
                 ipv4IpCheck     <- map["url_ipv4_check"]
                 ipv6IpCheck     <- map["url_ipv6_check"]
-                
-                
             }
         }
         

--- a/Sources/TestExportFormat.swift
+++ b/Sources/TestExportFormat.swift
@@ -20,13 +20,16 @@ extension TestExportFormat {
         }
     }
 
-    func httpBody(openTestUUID: String) -> Data? {
-        switch self {
+    func httpBody(openTestUUIDs: [String], maxResults: Int? = nil) -> Data? {
+        let uuidList = openTestUUIDs.joined(separator: ",")
+        let maxResultsStr = maxResults.map { ",maxResults=\($0)" } ?? ""
+
+        return switch self {
         case .pdf:
-            Data("open_test_uuid=\(openTestUUID)".utf8)
+            Data("open_test_uuid=\(uuidList)".utf8)
 
         case .xlsx, .csv:
-            Data("open_test_uuid=\(openTestUUID)&format=\(format)".utf8)
+            Data("open_test_uuid=\(uuidList)&format=\(format)\(maxResultsStr)".utf8)
         }
     }
 
@@ -38,10 +41,10 @@ extension TestExportFormat {
         }
     }
 
-    func downloadRequest(baseURL: URL, openTestUUID: String) -> URLRequest {
+    func downloadRequest(baseURL: URL, openTestUUIDs: [String], maxResults: Int? = nil) -> URLRequest {
         var request = URLRequest(url: baseURL.appending(path: urlPath))
         request.httpMethod = "POST"
-        request.httpBody = httpBody(openTestUUID: openTestUUID)
+        request.httpBody = httpBody(openTestUUIDs: openTestUUIDs, maxResults: maxResults)
 
         return request
     }

--- a/Sources/TestExportFormat.swift
+++ b/Sources/TestExportFormat.swift
@@ -22,15 +22,17 @@ extension TestExportFormat {
 
     func httpBody(openTestUUIDs: [String], maxResults: Int? = nil) -> Data? {
         let uuidList = openTestUUIDs.joined(separator: ",")
-        let maxResultsStr = maxResults.map { ",maxResults=\($0)" } ?? ""
+        let maxResultsStr = maxResults.map { "&maxResults=\($0)" } ?? ""
+        let httpBodyStr: String
 
-        return switch self {
-        case .pdf:
-            Data("open_test_uuid=\(uuidList)".utf8)
-
-        case .xlsx, .csv:
-            Data("open_test_uuid=\(uuidList)&format=\(format)\(maxResultsStr)".utf8)
+        httpBodyStr = switch self {
+        case .pdf: 
+            "open_test_uuid=\(uuidList)"
+        case .xlsx, .csv: 
+            "open_test_uuid=\(uuidList)&format=\(format)\(maxResultsStr)"
         }
+
+        return httpBodyStr.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed).map { Data($0.utf8) }
     }
 
     private var format: String {


### PR DESCRIPTION
This PR adds export buttons to the History Index screen and refines URLs and requests to support exporting multiple tests at once.

<img src="https://github.com/appscape/open-rmbt-ios/assets/244850/aac75366-1c78-4889-aab6-60f09b887e9a" width=40% height=40%>
